### PR TITLE
Fix voidRequest calls

### DIFF
--- a/src/main/java/ar/com/todopago/api/rest/OperationsParser.java
+++ b/src/main/java/ar/com/todopago/api/rest/OperationsParser.java
@@ -85,13 +85,12 @@ public class OperationsParser {
 
 		while (Itr.hasNext()) {
 			String name = Itr.next();
-			String a = jsonObject.getString(name);
-			if (a.contains("{")) {
-				JSONObject jsonObject2 = (JSONObject) jsonObject.get(name);
+			Object a = jsonObject.get(name);
+			if (a instanceof String && ((String) a).startsWith("{")) {
 				auxMap.put(name, null);
-				generateMap(jsonObject2, auxMap, name);
+				generateMap(new JSONObject(a), auxMap, name);
 			} else {
-				auxMap.put(name, jsonObject.getString(name));
+				auxMap.put(name, a);
 			}
 		}
 		if (key != null) {

--- a/src/main/java/ar/com/todopago/api/rest/OperationsParser.java
+++ b/src/main/java/ar/com/todopago/api/rest/OperationsParser.java
@@ -89,8 +89,11 @@ public class OperationsParser {
 			if (a instanceof String && ((String) a).startsWith("{")) {
 				auxMap.put(name, null);
 				generateMap(new JSONObject(a), auxMap, name);
-			} else {
+			} else if (a instanceof String) {
 				auxMap.put(name, a);
+			} else if (a instanceof JSONObject) {
+				auxMap.put(name, null);
+				generateMap((JSONObject) a, auxMap, name);
 			}
 		}
 		if (key != null) {

--- a/src/main/java/ar/com/todopago/api/rest/OperationsParser.java
+++ b/src/main/java/ar/com/todopago/api/rest/OperationsParser.java
@@ -89,11 +89,11 @@ public class OperationsParser {
 			if (a instanceof String && ((String) a).startsWith("{")) {
 				auxMap.put(name, null);
 				generateMap(new JSONObject(a), auxMap, name);
-			} else if (a instanceof String) {
-				auxMap.put(name, a);
 			} else if (a instanceof JSONObject) {
 				auxMap.put(name, null);
 				generateMap((JSONObject) a, auxMap, name);
+			} else {
+				auxMap.put(name, a);
 			}
 		}
 		if (key != null) {


### PR DESCRIPTION
Current implementation does not support the case when the JSON String contains nested data, as it is the case with the response from the voidRequest service that returns something along the lines of:
```
{
  "VoidResponse":{
    "StatusCode":2013,
    "StatusMessage":"...",
    "AuthorizationKey":"...",
    "AUTHORIZATIONCODE":null
  }
}
```
In that case the `JSONObject::getString` method throws an exception since the content of the `VoidResponse` key is not a `String`